### PR TITLE
Fix codedov link & badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 A node module to color console messages.
 
 [![Build Status](https://travis-ci.org/talonbragg/message-palette.svg?branch=master)](https://travis-ci.org/talonbragg/message-palette)
-<a href="https://codecov.io/gh/talonbragg/apihandler"><img src="https://codecov.io/gh/talonbragg/apihandler/branch/master/graph/badge.svg" alt="Code Coverage"></a>
+<a href="https://codecov.io/gh/talonbragg/message-palette"><img src="https://codecov.io/gh/talonbragg/message-palette/branch/master/graph/badge.svg" alt="Code Coverage"></a>
 
 **Installation**
 


### PR DESCRIPTION
codecov link was pointing to another project (talonbragg/apihandler)